### PR TITLE
Fix wrong parameter notation and add more error handlers

### DIFF
--- a/boat-rest-service/src/main/java/it/univaq/dandd/boat_rest_service/controller/BoatController.java
+++ b/boat-rest-service/src/main/java/it/univaq/dandd/boat_rest_service/controller/BoatController.java
@@ -2,10 +2,10 @@ package it.univaq.dandd.boat_rest_service.controller;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,10 +16,10 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import it.univaq.dandd.boat_rest_service.exception.IdParsingException;
 import it.univaq.dandd.boat_rest_service.model.NauticalRoute;
 import it.univaq.dandd.boat_rest_service.service.NauticalRouteService;
 import it.univaq.dandd.boat_rest_service.service.NauticalRouteServiceImpl;
-import jakarta.websocket.server.PathParam;
 
 @RestController
 @RequestMapping("/boats")
@@ -96,6 +96,14 @@ public class BoatController {
 								  ) 
 				  }),
 		  @ApiResponse(
+				  responseCode = "400",
+				  description = "The ID path parameter is invalid.", 
+				  content = {
+						  @Content(
+								  mediaType = "application/json"
+								  )
+				  }),
+		  @ApiResponse(
 				  responseCode = "404",
 				  description = "Route not found for this ID.", 
 				  content = {
@@ -113,7 +121,11 @@ public class BoatController {
 				  }) 
 	})
 	@GetMapping("/{id}/")
-	public ResponseEntity<NauticalRoute> findRoute(@PathParam(value = "id") long id) {
+	public ResponseEntity<NauticalRoute> findRoute(@PathVariable("id") Long id) {
+		//Throw exception if the ID is null (it's a failsafe in case this goes unnoticed to spring converter)
+		if(id==null) {
+			throw new IdParsingException("Invalid ID value.");
+		}
 		return new ResponseEntity<NauticalRoute>(nauticalRouteService.findRouteById(id), HttpStatus.OK);
 	}
 }

--- a/boat-rest-service/src/main/java/it/univaq/dandd/boat_rest_service/exception/ControllerExceptionHandler.java
+++ b/boat-rest-service/src/main/java/it/univaq/dandd/boat_rest_service/exception/ControllerExceptionHandler.java
@@ -3,19 +3,40 @@ package it.univaq.dandd.boat_rest_service.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 public class ControllerExceptionHandler {
 
+	//Exception thrown when ID doesn't match anything in the datasource
 	@ExceptionHandler(RouteNotFoundException.class)
     public ResponseEntity<ExceptionData>  handleTemplateNotFound(RouteNotFoundException ex) {
         return new ResponseEntity<>(new ExceptionData(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), ex.getLocalizedMessage()), HttpStatus.NOT_FOUND);
     }
 	
+	//Exception thrown when a PathVariable can't be parsed
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<ExceptionData>  handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException ex) {
+		//If this is caused by a number convertion exception, then it's from the controller endpoint: return HTTP 400.
+		if(ex.getCause() instanceof NumberFormatException) {
+			return handleIdParsingException(new IdParsingException("Invalid ID value", ex));
+		}
+		else { //If not, then it's an internal exception: return HTTP 500			
+			return handleGenericException(ex);
+		}
+    }
+	
+	//ID parsing exception handler (usually called by the handler above)
+	@ExceptionHandler(IdParsingException.class)
+	public ResponseEntity<ExceptionData>  handleIdParsingException(IdParsingException ex) {
+		return new ResponseEntity<>(new ExceptionData(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.value(), ex.getLocalizedMessage()), HttpStatus.BAD_REQUEST);
+    }
+	
+	//Generic, catch-all handler.
 	@ExceptionHandler(Throwable.class)
     public ResponseEntity<ExceptionData>  handleGenericException(Throwable ex) {
-        return new ResponseEntity<>(new ExceptionData(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.value(), "An unexpected error has occured."), HttpStatus.INTERNAL_SERVER_ERROR);
+        ex.printStackTrace();
+		return new ResponseEntity<>(new ExceptionData(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.value(), "An unexpected error has occured."), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/boat-rest-service/src/main/java/it/univaq/dandd/boat_rest_service/exception/IdParsingException.java
+++ b/boat-rest-service/src/main/java/it/univaq/dandd/boat_rest_service/exception/IdParsingException.java
@@ -1,0 +1,34 @@
+package it.univaq.dandd.boat_rest_service.exception;
+
+public class IdParsingException extends RuntimeException {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1780553338720345033L;
+
+	public IdParsingException() {
+		// TODO Auto-generated constructor stub
+	}
+
+	public IdParsingException(String message) {
+		super(message);
+		// TODO Auto-generated constructor stub
+	}
+
+	public IdParsingException(Throwable cause) {
+		super(cause);
+		// TODO Auto-generated constructor stub
+	}
+
+	public IdParsingException(String message, Throwable cause) {
+		super(message, cause);
+		// TODO Auto-generated constructor stub
+	}
+
+	public IdParsingException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+		// TODO Auto-generated constructor stub
+	}
+
+}

--- a/boat-rest-service/src/test/java/it/univaq/dandd/boat_rest_service/BoatControllerTests.java
+++ b/boat-rest-service/src/test/java/it/univaq/dandd/boat_rest_service/BoatControllerTests.java
@@ -3,14 +3,14 @@ package it.univaq.dandd.boat_rest_service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 import it.univaq.dandd.boat_rest_service.model.NauticalRoute;
 
@@ -25,30 +25,31 @@ public class BoatControllerTests {
     @LocalServerPort
     private int randomServerPort;
     
-    private final String template = "The sum is: %s!";
-    
     @Test
     void should_return_all_routes() {
-        List<NauticalRoute> routes = restTemplate.getForObject("http://localhost:" + randomServerPort + "/boats/all/", List.class);
+        NauticalRoute[] routes = restTemplate.getForObject("http://localhost:" + randomServerPort + "/boats/all/", NauticalRoute[].class);
         
         assertNotNull(routes);
-        assertEquals(2, routes.size());
+        assertEquals(2, routes.length);
     }
     
     @Test
     void should_return_all_pescara_routes() {
-        List<NauticalRoute> routes = restTemplate.getForObject("http://localhost:" + randomServerPort + "/boats/?departure=pescara", List.class);
+    	NauticalRoute[] routes = restTemplate.getForObject("http://localhost:" + randomServerPort + "/boats/?departure=pescara", NauticalRoute[].class);
         
         assertNotNull(routes);
-        assertEquals(1, routes.size());
-        assertEquals(routes.get(0).getDepartureName().toLowerCase(), "pescara");
+        assertEquals(1, routes.length);
+        assertEquals(routes[0].getDepartureName().toLowerCase(), "pescara");
     }
     
     @Test
     void should_return_route_with_id_1() {
-        NauticalRoute route = restTemplate.getForObject("http://localhost:" + randomServerPort + "/boats/1/", NauticalRoute.class);
+    	Long id = 1L;
+    	String url = "http://localhost:" + randomServerPort + "/boats/{id}/";
+        ResponseEntity<NauticalRoute> response = restTemplate.getForEntity(url, NauticalRoute.class, id);
         
-        assertNotNull(route);
-        assertEquals(1, route.getId());
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().getId());
     }
 }


### PR DESCRIPTION
- Fixed an incorrect notation on findRoute (/boats/{id}) endpoint parameter
- Added exception handling in case an invalid id is passed to findRoute, i.e. URI is "/boats/1a/" -> returns 400 - bad request.